### PR TITLE
Add command line option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,4 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
-
+*.env

--- a/bin/tinyme.js
+++ b/bin/tinyme.js
@@ -1,0 +1,5 @@
+#! /usr/bin/env node
+const tinyme = require('./../src/index');
+const folderPath = process.argv[2];
+
+tinyme(folderPath);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "start": "node src/index.js",
     "test": "eslint src"
   },
+  "bin": {
+    "tinyme": "bin/tinyme.js"
+  },
   "eslintConfig": {
     "extends": "eslint:recommended",
     "parserOptions": {

--- a/src/helpers/env.js
+++ b/src/helpers/env.js
@@ -1,10 +1,11 @@
 /**
  * Node modules
  */
-const dotenv = require('dotenv');
 const assert = require('assert');
+const dotenv = require('dotenv');
+const currentPath = process.cwd();
 
-dotenv.config({ path: 'variables.env' });
+dotenv.config({ path: `${currentPath}/variables.env` });
 
 /**
  * Gets env variables by its name. These variables are extracted by dotenv lib.

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,8 @@ const Logger = require('./helpers/logger');
 /**
  * Initializes the application.
  */
-async function initialize() {
+async function initialize(path) {
   try {
-    const path = process.argv[2];
     if (typeof path === 'undefined') {
       throw new Error('You have to define a path');
     }
@@ -22,4 +21,4 @@ async function initialize() {
   }
 }
 
-initialize();
+module.exports = initialize;


### PR DESCRIPTION
This commit adds a command line global `tinyme` when the module is installed globally.

Installation: you can install the module by `npm install -g tinyme".

Usage: From anywhere, run `tinyme ~/my/folder/`, the CLI will get the API_Kay from the variables.env *of the current folder* that you are.

Improvements:  Should be able to pass the key from the command line, like: `tinyme ~/my/folder/ My_API_KEY`

For local testing: run `npm link` and you should be able to run `tinyme` on our machine.